### PR TITLE
fix #6 Errosディレクトリの名称変換がされない問題を解決

### DIFF
--- a/src/Controller/Component/BcAddonMigrator5Component.php
+++ b/src/Controller/Component/BcAddonMigrator5Component.php
@@ -307,6 +307,10 @@ class {$plugin}Plugin extends BcPlugin {}");
 						rename($pluginPath . 'templates' . DS . $dir, $pluginPath . 'templates' . DS . 'email');
 						$this->moveAdminTemplates($plugin, 'email');
 						break;
+					case 'Errors':
+						rename($pluginPath . 'templates' . DS . $dir, $pluginPath . 'templates' . DS . 'error');
+						$this->moveAdminTemplates($plugin, 'error');
+						break;
 					default:
 						$this->moveAdminTemplates($plugin, $dir);
 						break;
@@ -365,6 +369,10 @@ class {$plugin}Plugin extends BcPlugin {}");
 				case 'Emails':
 					rename($pluginPath . $dir, $pluginPath . 'templates' . DS . 'email');
 					$this->moveAdminTemplates($plugin, 'email');
+					break;
+				case 'Errors':
+					rename($pluginPath . $dir, $pluginPath . 'templates' . DS . 'error');
+					$this->moveAdminTemplates($plugin, 'error');
 					break;
 				case 'templates':
 				case 'webroot':


### PR DESCRIPTION
@ryuring 
単純に Errosディレクトリをリネームする調整を入れています。
お手数ですが、ご確認の上、マージをお願いできますでしょうか？
※masterをブランチ前提としています。
